### PR TITLE
Implement address-change on samd (flash) & live address change

### DIFF
--- a/firmware/firmware_modules.h
+++ b/firmware/firmware_modules.h
@@ -15,6 +15,6 @@
 
 //#include "AccelStepperI2C_firmware.h"   // will not compile on Attinys
 //#include "ServoI2C_firmware.h"          // will not compile on Attinys
-//#include "PinI2C_firmware.h"            // should work on any platform
+#include "PinI2C_firmware.h"            // should work on any platform
 //#include "ESP32sensorsI2C_firmware.h"   // will only compile on ESP32 boards
 //#include "TM1638liteI2C_firmware.h"     // should work on any platform

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,6 @@ sentence=I2Cwrapper is a generic modular framework for Arduino I2C target device
 paragraph=Consists of an easily extensible firmware framework and a I2C controller library. Ready to use modules exist for stepper motors, servo motors, digital/analog pins, and ESP32 touch buttons.
 category=Device Control
 url=https://github.com/ftjuh/I2Cwrapper
-architectures=avr,esp32,esp8266
+architectures=avr,esp32,esp8266,samd
 includes=I2Cwrapper.h
+depends=FlashStorage

--- a/src/I2Cwrapper.h
+++ b/src/I2Cwrapper.h
@@ -115,6 +115,11 @@ public:
   void changeI2Caddress(uint8_t newAddress);
 
   /*!
+   * @brief Return the i2c address of whom we are talking to (from construction time)
+   */
+  uint8_t getAddress() { return address; }
+
+  /*!
    * @brief Define a global interrupt pin which can be used by device units
    * (steppers, servos...) to inform the controller that something important happend.
    * Currently used by AccelStepperI2C to inform about end stop hits and target


### PR DESCRIPTION
upload).
firmware/firmware.ino:
add eeprom emulator for samd.
more verbose about reading/writing stored address.
lengthen serial wait to allow arduino-ide to reopen serial console.
factor setup_wire() to re-use.
live address change if architectur supports it.
firmware/firmware_modules.h:
enable pini2c by default.
library.properties:
add "samd" to architectures.
add dependency on FlashStorage (eeprom emulator).
src/I2Cwrapper.h:
add getAddress()

(cherry picked from commit 82031ed9c0b986fab9624ab467bb1b297e154f37)